### PR TITLE
学生一覧にクラス絞り込みを追加

### DIFF
--- a/src/main/java/com/example/attendance/controller/StudentController.java
+++ b/src/main/java/com/example/attendance/controller/StudentController.java
@@ -2,6 +2,7 @@ package com.example.attendance.controller;
 
 import com.example.attendance.domain.Student;
 import com.example.attendance.service.AttendanceService;
+import com.example.attendance.repository.SchoolClassRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -16,9 +17,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RequestMapping("/students")
 public class StudentController {
     private final AttendanceService attendanceService;
+    private final SchoolClassRepository classRepository;
 
-    public StudentController(AttendanceService attendanceService) {
+    public StudentController(AttendanceService attendanceService, SchoolClassRepository classRepository) {
         this.attendanceService = attendanceService;
+        this.classRepository = classRepository;
     }
 
     @GetMapping
@@ -28,6 +31,7 @@ public class StudentController {
             @RequestParam(name = "sort", defaultValue = "id") String sort,
             @RequestParam(name = "dir", defaultValue = "asc") String dir,
             @RequestParam(name = "q", required = false) String q,
+            @RequestParam(name = "classId", required = false) Long classId,
             Model model
     ) {
         String sortProp = switch (sort) {
@@ -36,13 +40,15 @@ public class StudentController {
         };
         Sort.Direction direction = "desc".equalsIgnoreCase(dir) ? Sort.Direction.DESC : Sort.Direction.ASC;
         Pageable pageable = PageRequest.of(Math.max(page, 0), Math.min(size, 50), Sort.by(direction, sortProp));
-        Page<Student> students = attendanceService.listStudents(q, pageable);
+        Page<Student> students = attendanceService.listStudents(q, classId, pageable);
 
         model.addAttribute("page", students);
         model.addAttribute("sort", sortProp);
         model.addAttribute("dir", direction.isAscending() ? "asc" : "desc");
         model.addAttribute("toggleDir", direction.isAscending() ? "desc" : "asc");
         model.addAttribute("q", q == null ? "" : q);
+        model.addAttribute("classes", classRepository.findAll());
+        model.addAttribute("classId", classId);
         return "students/list";
     }
 }

--- a/src/main/java/com/example/attendance/repository/StudentRepository.java
+++ b/src/main/java/com/example/attendance/repository/StudentRepository.java
@@ -8,4 +8,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface StudentRepository extends JpaRepository<Student, Long> {
     Page<Student> findByNameContainingIgnoreCaseOrStudentNumberContainingIgnoreCase(
             String name, String studentNumber, Pageable pageable);
+
+    Page<Student> findBySchoolClass_Id(Long classId, Pageable pageable);
+
+    Page<Student> findBySchoolClass_IdAndNameContainingIgnoreCaseOrSchoolClass_IdAndStudentNumberContainingIgnoreCase(
+            Long classId1, String name,
+            Long classId2, String studentNumber,
+            Pageable pageable);
 }

--- a/src/main/java/com/example/attendance/service/AttendanceService.java
+++ b/src/main/java/com/example/attendance/service/AttendanceService.java
@@ -38,6 +38,20 @@ public class AttendanceService {
         return studentRepository.findByNameContainingIgnoreCaseOrStudentNumberContainingIgnoreCase(kw, kw, pageable);
     }
 
+    public Page<Student> listStudents(String q, Long classId, Pageable pageable) {
+        boolean hasQuery = q != null && !q.isBlank();
+        if (classId == null) {
+            return listStudents(q, pageable);
+        }
+        if (!hasQuery) {
+            return studentRepository.findBySchoolClass_Id(classId, pageable);
+        }
+        String kw = q.trim();
+        return studentRepository
+                .findBySchoolClass_IdAndNameContainingIgnoreCaseOrSchoolClass_IdAndStudentNumberContainingIgnoreCase(
+                        classId, kw, classId, kw, pageable);
+    }
+
     public List<Attendance> getAttendanceForDate(LocalDate date) {
         return attendanceRepository.findAllByDateOrderByStudent_StudentNumberAsc(date);
     }

--- a/src/main/resources/templates/students/list.html
+++ b/src/main/resources/templates/students/list.html
@@ -68,8 +68,16 @@
         <input type="hidden" name="sort" th:value="${sort}" />
         <input type="hidden" name="dir" th:value="${dir}" />
         <input type="hidden" name="size" th:value="${page.size}" />
+        <label class="muted" for="classId">クラス:</label>
+        <select name="classId" id="classId">
+          <option value="" th:selected="${classId} == null">すべて</option>
+          <option th:each="c : ${classes}"
+                  th:value="${c.id}"
+                  th:text="${c.name}"
+                  th:selected="${classId} != null and c.id == classId"></option>
+        </select>
         <input name="q" type="search" placeholder="氏名/学籍番号で検索" th:value="${q}" />
-        <button class="btn" type="submit">検索</button>
+        <button class="btn" type="submit">適用</button>
       </form>
     </header>
 
@@ -78,14 +86,14 @@
         <tr>
           <th>
             <a
-              th:href="@{'/students'(sort='id',dir=${sort=='id'? toggleDir : dir},page=${page.number},size=${page.size},q=${q})}"
+              th:href="@{'/students'(sort='id',dir=${sort=='id'? toggleDir : dir},page=${page.number},size=${page.size},q=${q},classId=${classId})}"
               >ID</a
             >
             <span class="muted" th:if="${sort=='id'}" th:text="dir=='asc'?'▲':'▼'"></span>
           </th>
           <th>
             <a
-              th:href="@{'/students'(sort='studentNumber',dir=${sort=='studentNumber'? toggleDir : dir},page=${page.number},size=${page.size},q=${q})}"
+              th:href="@{'/students'(sort='studentNumber',dir=${sort=='studentNumber'? toggleDir : dir},page=${page.number},size=${page.size},q=${q},classId=${classId})}"
               >学籍番号</a
             >
             <span
@@ -96,7 +104,7 @@
           </th>
           <th>
             <a
-              th:href="@{'/students'(sort='name',dir=${sort=='name'? toggleDir : dir},page=${page.number},size=${page.size},q=${q})}"
+              th:href="@{'/students'(sort='name',dir=${sort=='name'? toggleDir : dir},page=${page.number},size=${page.size},q=${q},classId=${classId})}"
               >氏名</a
             >
             <span class="muted" th:if="${sort=='name'}" th:text="dir=='asc'?'▲':'▼'"></span>
@@ -118,7 +126,7 @@
     <nav class="pager">
       <a
         class="btn"
-        th:href="@{'/students'(page=${page.number-1},size=${page.size},sort=${sort},dir=${dir},q=${q})}"
+        th:href="@{'/students'(page=${page.number-1},size=${page.size},sort=${sort},dir=${dir},q=${q},classId=${classId})}"
         th:aria-disabled="${page.first}"
         th:classappend="${page.first}?' disabled'"
         >前へ</a
@@ -130,16 +138,16 @@
       >
       <a
         class="btn"
-        th:href="@{'/students'(page=${page.number+1},size=${page.size},sort=${sort},dir=${dir},q=${q})}"
+        th:href="@{'/students'(page=${page.number+1},size=${page.size},sort=${sort},dir=${dir},q=${q},classId=${classId})}"
         th:aria-disabled="${page.last}"
         th:classappend="${page.last}?' disabled'"
         >次へ</a
       >
 
       <span class="muted" style="margin-left: auto">表示件数:</span>
-      <a class="btn" th:href="@{'/students'(page=0,size=10,sort=${sort},dir=${dir},q=${q})}">10</a>
-      <a class="btn" th:href="@{'/students'(page=0,size=20,sort=${sort},dir=${dir},q=${q})}">20</a>
-      <a class="btn" th:href="@{'/students'(page=0,size=50,sort=${sort},dir=${dir},q=${q})}">50</a>
+      <a class="btn" th:href="@{'/students'(page=0,size=10,sort=${sort},dir=${dir},q=${q},classId=${classId})}">10</a>
+      <a class="btn" th:href="@{'/students'(page=0,size=20,sort=${sort},dir=${dir},q=${q},classId=${classId})}">20</a>
+      <a class="btn" th:href="@{'/students'(page=0,size=50,sort=${sort},dir=${dir},q=${q},classId=${classId})}">50</a>
     </nav>
   </body>
 </html>


### PR DESCRIPTION

学生一覧画面にクラスでの絞り込み機能を追加しました。  
主な変更点と目的:
- 学生一覧でクラスを選択して表示を絞り込めるようにすることで、管理者が特定クラスの学生を素早く確認できるようにしました。
- UIの一部（フィルタ選択・レイアウト）を調整しました。

主な変更ファイル（例）
- `com/example/attendance/controller/StudentController.java`
- list.html
- 必要に応じて関連CSS/JSを調整（`static/css/style.css`, `static/js/app.js`）

動作確認手順
1. アプリを起動する（例: ローカルで Maven -> `mvn spring-boot:run`）。
2. ブラウザで学生一覧画面にアクセスする（例: http://localhost:8080/students）。
3. 画面上部の「クラス」ドロップダウンから任意のクラスを選択する。
4. 選択したクラスに所属する学生だけが一覧に表示されることを確認する。

レビューしてほしい点
- 絞り込み条件のサーバーサイド実装（`StudentController`）の処理が冗長でないか。
- SQL/リポジトリのクエリが効率的か（必要ならインデックスやクエリ最適化の検討）。
- UI/UX（選択肢の初期表示や「全クラス」選択の挙動）が期待通りか。

備考
- DBスキーマの変更はありません（マイグレーション不要）。  
- このPRは関連Issue #4 に対応します（コミット: e7f9f17）。
