### PR TITLE
fix: replace question mark with exclamation mark for password reminder

### DIFF
--- a/login.html
+++ b/login.html
@@ -119,7 +119,7 @@
 
           <div class="row">
             <label class="checkbox"><input type="checkbox" id="remember" /> 次回から自動的にログイン</label>
-            <a class="link" href="#" aria-label="パスワードをお忘れですか？">パスワードをお忘れですか？</a>
+            <a class="link" href="#" aria-label="パスワードをお忘れですか！">パスワードをお忘れですか！</a>
           </div>
 
           <button class="btn" type="submit">ログイン</button>


### PR DESCRIPTION
## Summary
- replace question mark with exclamation mark in password reset link text and aria label

## Testing
- `mvn test` *(fails: 'dependencies.dependency.version' missing for com.h2database:h2:jar)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dd6492488332a236e00f37be1be0